### PR TITLE
Elasticsearch version 6.2

### DIFF
--- a/playbooks/upshift-stage-es-no-cert-regen-6.2.yaml
+++ b/playbooks/upshift-stage-es-no-cert-regen-6.2.yaml
@@ -1,0 +1,70 @@
+---
+- name: install elasticsearch
+  hosts: masters
+  roles:
+  - role: openshift_logging_elasticsearch
+    vars:
+      openshift_image_tag: v3.10
+      kubeconfig: /home/longuyen/.kube/config
+      openshift_is_containerized: false
+      __es_version: "5.5"
+      __base_file_dir: "6.x"
+      openshift_logging_es5_techpreview: true
+      openshift_logging_image_version: latest
+      openshift_logging_elasticsearch_proxy_image_prefix: "docker.io/openshift/"
+      openshift_logging_elasticsearch_proxy_image_version: "v1.0.0"
+      openshift_logging_es_log_appenders: ['file']
+      openshift_logging_elasticsearch_namespace: "dh-stage-storage"
+      openshift_logging_namespace: dh-stage-storage
+      openshift_logging_elasticsearch_clustername: "elastic1"
+      openshift_logging_elasticsearch_sa_name: "sa-elasticsearch"
+      openshift_logging_elasticsearch_clusterreader: false
+      generated_certs_dir: /home/longuyen/prod-es-certs
+      openshift_logging_elasticsearch_transport_cert_name: "elasticsearch"
+      openshift_logging_elasticsearch_api_cert_name: "logging-es"
+      openshift_logging_elasticsearch_prometheus_sa: system:serviceaccount:dh-stage-storage:prometheus
+      oc_username: developer
+      openshift_logging_es_nodeselector: {}
+      openshift_logging_elasticsearch_node_topology:
+      - node_role:  master
+        replicas: 3
+        storage_group: 65534
+        node_storage_type: emptydir
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 1Gi
+          cpu: 200m
+      - node_role:  clientdata
+        storage_group: 65534
+        node_storage_type: pvc
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        pvc_name: dh-stage-storage-pvc-1
+      - node_role:  clientdata
+        storage_group: 65534
+        node_storage_type: pvc
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        pvc_name: dh-stage-storage-pvc-2
+      - node_role:  clientdata
+        storage_group: 65534
+        node_storage_type: pvc
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        pvc_name: dh-stage-storage-pvc-3
+      openshift_logging_elasticsearch_log_appenders: console
+      openshift_logging_elasticsearch_node_topology_defined: "true"
+      openshift_logging_elasticsearch_allow_external: true
+      openshift_logging_image_prefix: quay.io/longnguyennn/
+      openshift_logging_image_pull_secret: ''
+      openshift_logging_es_hostname: 192.168.42.126.nip.io

--- a/roles/openshift_logging_certs/tasks/main.yaml
+++ b/roles/openshift_logging_certs/tasks/main.yaml
@@ -84,15 +84,15 @@
   when:
     - not ca_db_file.stat.exists
 
-- name: Checking for ca.crt.srl
-  stat: path="{{generated_certs_dir}}/ca.crt.srl"
-  register: ca_cert_srl_file
+- name: Checking for ca.crl.srl
+  stat: path="{{generated_certs_dir}}/ca.crl.srl"
+  register: ca_crl_srl_file
   check_mode: no
 
-- copy: content="" dest={{generated_certs_dir}}/ca.crt.srl
+- copy: content="" dest={{generated_certs_dir}}/ca.crl.srl
   check_mode: no
   when:
-    - not ca_cert_srl_file.stat.exists
+    - not ca_crl_srl_file.stat.exists
 
 - name: Generate PEM certs
   include: generate_pems.yaml component={{node_name}}

--- a/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/node_provision.yaml
@@ -5,36 +5,30 @@
 
 - name: Client nodes must have http service enabled
   set_fact:
-    es_http_service: "1"
+    es_http_service: true
   when: es_role in ["clientdata", "clientdatamaster", "client"]
 
 - set_fact:
-    es_http_service: "0"
+    es_http_service: false
   when: es_role in ["master", "data"]
 
 - name: Define whether this is a master node
   set_fact:
-    node_master: "0"
+    node_master: false
   when: es_role in ["client", "data", "clientdata"]
 
 - set_fact:
-    node_master: "1"
+    node_master: true
   when: es_role in ["master", "clientdatamaster"]
 
 - name: Define whether this is a data node
   set_fact:
-    node_data: "1"
+    node_data: true
   when: es_role in ["data", "clientdata", "clientdatamaster"]
 
 - set_fact:
-    node_data: "0"
+    node_data: false
   when: es_role in ["client", "master"]
-
-- debug:
-    var: es_http_service
-
-- debug:
-    var: node_master
 
 # allow passing in a tempdir
 - name: Create temp directory for doing work in for role {{ es_role }}
@@ -223,7 +217,6 @@
   when: es_dc_creation.changed | bool
 
 ## Placeholder for migration when necessary ##
-
 - name: Delete temp directory
   file:
     name: "{{ tempdir }}"

--- a/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
+++ b/roles/openshift_logging_elasticsearch/tasks/svcs_routes.yaml
@@ -17,7 +17,7 @@
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     selector:
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
-      es-node-master: "1"
+      es-node-master: "True"
     labels:
       logging-infra: 'support'
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
@@ -33,7 +33,7 @@
     namespace: "{{ openshift_logging_elasticsearch_namespace }}"
     selector:
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"
-      es-node-client: "1"
+      es-node-client: "True"
     labels:
       logging-infra: 'support'
       cluster-name: "{{ openshift_logging_elasticsearch_clustername }}"

--- a/roles/openshift_logging_elasticsearch/templates/6.x/elasticsearch.yml.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/elasticsearch.yml.j2
@@ -1,0 +1,81 @@
+cluster:
+  name: ${CLUSTER_NAME}
+
+#script:
+#  inline: true
+#  stored: true
+
+node:
+  name: ${NODE_NAME}
+  master: ${IS_MASTER}
+  data: ${HAS_DATA}
+  max_local_storage_nodes: 1
+
+network:
+  host: 0.0.0.0
+
+cloud:
+  kubernetes:
+    service: ${SERVICE_DNS}
+    namespace: ${NAMESPACE}
+
+discovery.zen:
+  hosts_provider: kubernetes
+  minimum_master_nodes: ${NODE_QUORUM}
+
+gateway:
+  recover_after_nodes: ${NODE_QUORUM}
+  expected_nodes: ${RECOVER_EXPECTED_NODES}
+  recover_after_time: ${RECOVER_AFTER_TIME}
+
+#io.fabric8.elasticsearch.kibana.mapping.app: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json
+#io.fabric8.elasticsearch.kibana.mapping.ops: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json
+#io.fabric8.elasticsearch.kibana.mapping.empty: /usr/share/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json
+#
+#openshift.config:
+#  use_common_data_model: true
+#  project_index_prefix: "project"
+#  time_field_name: "@timestamp"
+#
+#openshift.searchguard:
+#  keystore.path: /etc/elasticsearch/secret/admin.jks
+#  truststore.path: /etc/elasticsearch/secret/searchguard.truststore
+#
+#openshift.operations.allow_cluster_reader: {{allow_cluster_reader | default (false)}}
+#
+#openshift.kibana.index.mode: {{es_kibana_index_mode | default('unique')}}
+
+path:
+  data:
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+  - /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% else %}
+  - /elasticsearch/persistent/
+{% endif %}
+  logs: /elasticsearch/${CLUSTER_NAME}/logs
+
+searchguard:
+  authcz.admin_dn:
+  - CN=system.admin,OU=OpenShift,O=Logging
+  config_index_name: ".searchguard.${DC_NAME}"
+  ssl:
+    transport:
+      enabled: true
+      enforce_hostname_verification: false
+      keystore_type: JKS
+      keystore_filepath: /etc/elasticsearch/secret/searchguard.key
+      keystore_password: kspass
+      truststore_type: JKS
+      truststore_filepath: /etc/elasticsearch/secret/searchguard.truststore
+      truststore_password: tspass
+    http:
+      enabled: true
+      keystore_type: JKS
+      keystore_filepath: /etc/elasticsearch/secret/key
+      keystore_password: kspass
+      clientauth_mode: OPTIONAL
+      truststore_type: JKS
+      truststore_filepath: /etc/elasticsearch/secret/truststore
+      truststore_password: tspass

--- a/roles/openshift_logging_elasticsearch/templates/6.x/es.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/es.j2
@@ -1,0 +1,234 @@
+apiVersion: "v1"
+kind: "DeploymentConfig"
+metadata:
+  name: "{{deploy_name}}"
+  labels:
+    provider: openshift
+    component: "{{es_component}}"
+    deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
+    logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    es-node-client: "{{ es_http_service }}"
+    es-node-data: "{{ node_data }}"
+    es-node-master: "{{ node_master }}"
+spec:
+  replicas: {{es_replicas|default(1)}}
+  revisionHistoryLimit: 0
+  selector:
+    provider: openshift
+    component: "{{es_component}}"
+    deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
+    logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    es-node-client: "{{ es_http_service }}"
+    es-node-data: "{{ node_data }}"
+    es-node-master: "{{ node_master }}"
+  strategy:
+    type: Recreate
+  triggers: []
+  template:
+    metadata:
+      name: "{{deploy_name}}"
+      labels:
+        logging-infra: "{{logging_component}}"
+        provider: openshift
+        component: "{{es_component}}"
+        deployment: "{{deploy_name}}"
+        cluster-name: "{{ es_cluster_name }}"
+        es-node-role: "{{ es_role }}"
+        es-node-client: "{{ es_http_service }}"
+        es-node-data: "{{ node_data }}"
+        es-node-master: "{{ node_master }}"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: logging-infra
+                  operator: In
+                  values:
+                  - elasticsearch
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriod: 600
+      serviceAccountName: {{ openshift_logging_elasticsearch_sa_name }}
+      securityContext:
+        supplementalGroups:
+{% for group in es_storage_groups %}
+        - {{group}}
+{% endfor %}
+{% if es_node_selector is iterable and es_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in es_node_selector.items() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+      containers:
+        - name: "elasticsearch"
+          image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch-6.2:{{ openshift_logging_elasticsearch_image_version }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+{% if limits is defined %}
+            limits:
+{% for key, value in limits.items() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if requests is defined %}
+            requests:
+{% for key, value in requests.items() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if es_container_security_context %}
+          securityContext: {{ es_container_security_context | to_yaml }}
+{% endif %}
+          livenessProbe:
+            tcpSocket:
+              port: 9300
+            initialDelaySeconds: 480
+            periodSeconds: 5
+          readinessProbe:
+{% if 'master' == es_role %}
+            tcpSocket:
+              port: 9300
+{% else %}
+            exec:
+              command:
+              - "/usr/share/elasticsearch/probe/readiness.sh"
+              initialDelaySeconds: 10
+              timeoutSeconds: 30
+              periodSeconds: 5
+{% endif %}
+          ports:
+            -
+              containerPort: 9200
+              name: "restapi"
+            -
+              containerPort: 9300
+              name: "cluster"
+          env:
+            -
+              name: "DC_NAME"
+              value: "{{deploy_name}}"
+            -
+              name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
+              name: "POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            -
+              name: "SERVICE_DNS"
+              value: "{{es_cluster_name}}-cluster"
+            -
+              name: "CLUSTER_NAME"
+              value: "{{es_cluster_name}}"
+            -
+              name: "INSTANCE_RAM"
+{% if limits is defined and limits.memory is defined %}
+              value: "{{ limits.memory }}"
+{% else %}
+              value: "512m"
+{% endif %}
+            -
+              name: "HEAP_DUMP_LOCATION"
+              value: "/elasticsearch/persistent/heapdump.hprof"
+            -
+              name: "READINESS_PROBE_TIMEOUT"
+              value: "30"
+            -
+              name: "POD_LABEL"
+              value: "component={{component}}"
+            -
+              name: IS_MASTER
+              value: "{{ node_master | lower }}"
+            -
+              name: HAS_DATA
+              value: "{{ node_data | lower }}"
+            -
+              name: "PROMETHEUS_USER"
+              value: "{{openshift_logging_elasticsearch_prometheus_sa}}"
+          volumeMounts:
+            - name: elasticsearch
+              mountPath: /etc/elasticsearch/secret
+              readOnly: true
+            - name: elasticsearch-config
+              mountPath: /usr/share/java/elasticsearch/config
+              readOnly: true
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+            - name: elasticsearch-storage-{{ loop.index0 }}
+              mountPath: /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% else %}
+            - name: elasticsearch-storage
+              mountPath: /elasticsearch/persistent
+{% endif %}
+        -
+          name: proxy
+          image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
+          imagePullPolicy: IfNotPresent
+          args:
+           - --upstream-ca=/etc/elasticsearch/secret/admin-ca
+           - --https-address=:4443
+           - -provider=openshift
+           - -client-id=system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch
+           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+           - -cookie-secret={{ 16 | lib_utils_oo_random_word | b64encode }}
+           - -basic-auth-password={{ basic_auth_passwd }}
+           - -upstream=https://localhost:9200
+           - '-openshift-sar={"namespace": "{{ openshift_logging_elasticsearch_namespace}}", "verb": "view", "resource": "prometheus", "group": "metrics.openshift.io"}'
+           - '-openshift-delegate-urls={"/": {"resource": "prometheus", "verb": "view", "group": "metrics.openshift.io", "namespace": "{{ openshift_logging_elasticsearch_namespace}}"}}'
+           - --tls-cert=/etc/tls/private/tls.crt
+           - --tls-key=/etc/tls/private/tls.key
+           - -pass-access-token
+           - -pass-user-headers
+          ports:
+          - containerPort: 4443
+            name: proxy
+            protocol: TCP
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: proxy-tls
+            readOnly: true
+          - mountPath: /etc/elasticsearch/secret
+            name: elasticsearch
+            readOnly: true
+          resources:
+            limits:
+              memory: "{{openshift_logging_elasticsearch_proxy_memory_limit }}"
+            requests:
+              cpu: "{{openshift_logging_elasticsearch_proxy_cpu_request }}"
+              memory: "{{openshift_logging_elasticsearch_proxy_memory_limit }}"
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: prometheus-tls
+        - name: elasticsearch
+          secret:
+            secretName: {{ es_cluster_name }}-certs
+        - name: elasticsearch-config
+          configMap:
+            name: {{ es_configmap }}
+{% if storage_type == 'pvc' %}
+        - name: elasticsearch-storage
+          persistentVolumeClaim:
+            claimName: {{ openshift_logging_elasticsearch_pvc_name }}
+{% elif storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+        - name: elasticsearch-storage-{{ loop.index0 }}
+          hostPath:
+            path: {{ item }}
+{% endfor %}
+{% else %}
+        - name: elasticsearch-storage
+          emptydir: {}
+{% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/6.x/log4j2.properties.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/log4j2.properties.j2
@@ -1,0 +1,77 @@
+status = error
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+appender.rolling.type = RollingFile
+appender.rolling.name = rolling
+appender.rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+
+rootLogger.level = info
+{% if 'console' in root_logger  %}
+rootLogger.appenderRef.console.ref = console
+{% endif %}
+{% if 'file' in root_logger %}
+rootLogger.appenderRef.rolling.ref = rolling
+{% endif %}
+appender.deprecation_rolling.type = RollingFile
+appender.deprecation_rolling.name = deprecation_rolling
+appender.deprecation_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.deprecation_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
+appender.deprecation_rolling.policies.type = Policies
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = 1GB
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = 4
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
+logger.deprecation.additivity = false
+
+appender.index_search_slowlog_rolling.type = RollingFile
+appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
+appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
+appender.index_search_slowlog_rolling.layout.type = PatternLayout
+appender.index_search_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
+appender.index_search_slowlog_rolling.policies.type = Policies
+appender.index_search_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_search_slowlog_rolling.policies.time.interval = 1
+appender.index_search_slowlog_rolling.policies.time.modulate = true
+
+logger.index_search_slowlog_rolling.name = index.search.slowlog
+logger.index_search_slowlog_rolling.level = trace
+logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref = index_search_slowlog_rolling
+logger.index_search_slowlog_rolling.additivity = false
+
+appender.index_indexing_slowlog_rolling.type = RollingFile
+appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
+appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
+appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
+appender.index_indexing_slowlog_rolling.policies.type = Policies
+appender.index_indexing_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_indexing_slowlog_rolling.policies.time.interval = 1
+appender.index_indexing_slowlog_rolling.policies.time.modulate = true
+
+logger.index_indexing_slowlog.name = index.indexing.slowlog.index
+logger.index_indexing_slowlog.level = trace
+logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
+logger.index_indexing_slowlog.additivity = false

--- a/roles/openshift_logging_elasticsearch/templates/6.x/logging-metrics-role.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/logging-metrics-role.j2
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: prometheus-metrics-viewer
+  namespace: {{ namespace }}
+rules:
+- apiGroups:
+  - metrics.openshift.io
+  resources:
+  - prometheus
+  verbs:
+  - view

--- a/roles/openshift_logging_elasticsearch/templates/6.x/logging-metrics-rolebinding.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/logging-metrics-rolebinding.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: prometheus-metrics-viewer
+  namespace: {{ namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-metrics-viewer
+subjects:
+- kind: ServiceAccount
+  namespace: {{ role_namespace }}
+  name: {{ role_user }}

--- a/roles/openshift_logging_elasticsearch/templates/6.x/master-statefulset.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/master-statefulset.j2
@@ -1,0 +1,235 @@
+apiVersion: "apps/v1beta1"
+kind: "StatefulSet"
+metadata:
+  name: "{{deploy_name}}"
+  labels:
+    provider: openshift
+    component: "{{es_component}}"
+    deployment: "{{deploy_name}}"
+    cluster-name: "{{ es_cluster_name }}"
+    logging-infra: "{{logging_component}}"
+    es-node-role: "{{ es_role }}"
+    es-node-client: "{{ es_http_service }}"
+    es-node-data: "{{ node_data }}"
+    es-node-master: "{{ node_master }}"
+spec:
+  podManagementPolicy: Parallel
+  replicas: {{es_replicas|default(1)}}
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      provider: openshift
+      deployment: "{{deploy_name}}"
+      cluster-name: "{{ es_cluster_name }}"
+      logging-infra: "{{logging_component}}"
+      es-node-role: "{{ es_role }}"
+      es-node-client: "{{ es_http_service }}"
+      es-node-data: "{{ node_data }}"
+      es-node-master: "{{ node_master }}"
+  serviceName: "{{ es_cluster_name }}-cluster"
+  template:
+    metadata:
+      name: "{{deploy_name}}"
+      labels:
+        logging-infra: "{{logging_component}}"
+        provider: openshift
+        component: "{{es_component}}"
+        deployment: "{{deploy_name}}"
+        cluster-name: "{{ es_cluster_name }}"
+        es-node-role: "{{ es_role }}"
+        es-node-client: "{{ es_http_service }}"
+        es-node-data: "{{ node_data }}"
+        es-node-master: "{{ node_master }}"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: logging-infra
+                  operator: In
+                  values:
+                  - elasticsearch
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriod: 600
+      serviceAccountName: {{ openshift_logging_elasticsearch_sa_name }}
+      securityContext:
+        supplementalGroups:
+{% for group in es_storage_groups %}
+        - {{group}}
+{% endfor %}
+{% if es_node_selector is iterable and es_node_selector | length > 0 %}
+      nodeSelector:
+{% for key, value in es_node_selector.items() %}
+        {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+      containers:
+        - name: "elasticsearch"
+          image: "{{ openshift_logging_elasticsearch_image_prefix }}logging-elasticsearch-6.2:{{ openshift_logging_elasticsearch_image_version }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+{% if limits is defined %}
+            limits:
+{% for key, value in limits.items() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if requests is defined %}
+            requests:
+{% for key, value in requests.items() %}
+              {{key}}: "{{value}}"
+{% endfor %}
+{% endif %}
+{% if es_container_security_context %}
+          securityContext: {{ es_container_security_context | to_yaml }}
+{% endif %}
+          livenessProbe:
+            tcpSocket:
+              port: 9300
+            initialDelaySeconds: 480
+            periodSeconds: 5
+          readinessProbe:
+{% if 'master' == es_role %}
+            tcpSocket:
+              port: 9300
+{% else %}
+            exec:
+              command:
+              - "/usr/share/elasticsearch/probe/readiness.sh"
+              initialDelaySeconds: 10
+              timeoutSeconds: 30
+              periodSeconds: 5
+{% endif %}
+          ports:
+            -
+              containerPort: 9200
+              name: "restapi"
+            -
+              containerPort: 9300
+              name: "cluster"
+          env:
+            -
+              name: "DC_NAME"
+              value: "{{deploy_name}}"
+            -
+              name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            -
+              name: "POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            -
+              name: "SERVICE_DNS"
+              value: "{{es_cluster_name}}-cluster"
+            -
+              name: "CLUSTER_NAME"
+              value: "{{es_cluster_name}}"
+            -
+              name: "INSTANCE_RAM"
+{% if limits is defined and limits.memory is defined %}
+              value: "{{ limits.memory }}"
+{% else %}
+              value: "512m"
+{% endif %}
+            -
+              name: "HEAP_DUMP_LOCATION"
+              value: "/elasticsearch/persistent/heapdump.hprof"
+            -
+              name: "READINESS_PROBE_TIMEOUT"
+              value: "30"
+            -
+              name: "POD_LABEL"
+              value: "component={{component}}"
+            -
+              name: IS_MASTER
+              value: "{{ node_master | lower }}"
+            -
+              name: HAS_DATA
+              value: "{{ node_data | lower }}"
+            -
+              name: "PROMETHEUS_USER"
+              value: "{{openshift_logging_elasticsearch_prometheus_sa}}"
+          volumeMounts:
+            - name: elasticsearch
+              mountPath: /etc/elasticsearch/secret
+              readOnly: true
+            - name: elasticsearch-config
+              mountPath: /usr/share/java/elasticsearch/config
+              readOnly: true
+{% if storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+            - name: elasticsearch-storage-{{ loop.index0 }}
+              mountPath: /elasticsearch/persistent/{{ loop.index0 }}
+{% endfor %}
+{% else %}
+            - name: elasticsearch-storage
+              mountPath: /elasticsearch/persistent
+{% endif %}
+        -
+          name: proxy
+          image: "{{ openshift_logging_elasticsearch_proxy_image_prefix }}oauth-proxy:{{ openshift_logging_elasticsearch_proxy_image_version }}"
+          imagePullPolicy: IfNotPresent
+          args:
+           - --upstream-ca=/etc/elasticsearch/secret/admin-ca
+           - --https-address=:4443
+           - -provider=openshift
+           - -client-id=system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch
+           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+           - -cookie-secret={{ 16 | lib_utils_oo_random_word | b64encode }}
+           - -basic-auth-password={{ basic_auth_passwd }}
+           - -upstream=https://localhost:9200
+           - '-openshift-sar={"namespace": "{{ openshift_logging_elasticsearch_namespace}}", "verb": "view", "resource": "prometheus", "group": "metrics.openshift.io"}'
+           - '-openshift-delegate-urls={"/": {"resource": "prometheus", "verb": "view", "group": "metrics.openshift.io", "namespace": "{{ openshift_logging_elasticsearch_namespace}}"}}'
+           - --tls-cert=/etc/tls/private/tls.crt
+           - --tls-key=/etc/tls/private/tls.key
+           - -pass-access-token
+           - -pass-user-headers
+          ports:
+          - containerPort: 4443
+            name: proxy
+            protocol: TCP
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: proxy-tls
+            readOnly: true
+          - mountPath: /etc/elasticsearch/secret
+            name: elasticsearch
+            readOnly: true
+          resources:
+            limits:
+              memory: "{{openshift_logging_elasticsearch_proxy_memory_limit }}"
+            requests:
+              cpu: "{{openshift_logging_elasticsearch_proxy_cpu_request }}"
+              memory: "{{openshift_logging_elasticsearch_proxy_memory_limit }}"
+      volumes:
+        - name: proxy-tls
+          secret:
+            secretName: prometheus-tls
+        - name: elasticsearch
+          secret:
+            secretName: {{ es_cluster_name }}-certs
+        - name: elasticsearch-config
+          configMap:
+            name: {{ es_configmap }}
+{% if storage_type == 'pvc' %}
+        - name: elasticsearch-storage
+          persistentVolumeClaim:
+            claimName: {{ openshift_logging_elasticsearch_pvc_name }}
+{% elif storage_type == 'hostmount' %}
+{% for item in hostmount_path %}
+        - name: elasticsearch-storage-{{ loop.index0 }}
+          hostPath:
+            path: {{ item }}
+{% endfor %}
+{% else %}
+        - name: elasticsearch-storage
+          emptydir: {}
+{% endif %}
+  updateStrategy:
+    type: OnDelete

--- a/roles/openshift_logging_elasticsearch/templates/6.x/pvc.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/pvc.j2
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{obj_name}}
+  labels:
+    logging-infra: support
+{% if annotations is defined %}
+  annotations:
+{% for key,value in annotations.items() %}
+    {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+spec:
+{% if pv_selector is defined and pv_selector is mapping %}
+  selector:
+    matchLabels:
+{% for key,value in pv_selector.items() %}
+      {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+  accessModes:
+{% for mode in access_modes %}
+    - {{ mode }}
+{% endfor %}
+  resources:
+    requests:
+      storage: {{size}}
+{% if storage_class_name is defined %}
+  storageClassName: {{ storage_class_name }}
+{% endif %}

--- a/roles/openshift_logging_elasticsearch/templates/6.x/rolebinding.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/rolebinding.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: RoleBinding
+metadata:
+  name: {{obj_name}}
+roleRef:
+{% if roleRef.kind is defined %}
+  kind: {{ roleRef.kind }}
+{% endif %}
+  name: {{ roleRef.name }}
+subjects:
+{% for sub in subjects %}
+  - kind: {{ sub.kind }}
+    name: {{ sub.name }}
+{% endfor %}

--- a/roles/openshift_logging_elasticsearch/templates/6.x/route_reencrypt.j2
+++ b/roles/openshift_logging_elasticsearch/templates/6.x/route_reencrypt.j2
@@ -1,0 +1,20 @@
+apiVersion: "v1"
+kind: "Route"
+metadata:
+  name: "{{obj_name}}"
+{% if labels is defined%}
+  labels:
+{% for key, value in labels.items() %}
+    {{key}}: {{value}}
+{% endfor %}
+{% endif %}
+spec:
+  host: {{ route_host }}
+  tls:
+    termination: passthrough
+{% if edge_term_policy is defined and edge_term_policy | length > 0 %}
+    insecureEdgeTerminationPolicy: {{ edge_term_policy }}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ service_name }}


### PR DESCRIPTION
Add new playbook, template directory 6.x  and rewrite some of the tasks in `roles/openshift_logging_elasticsearch` for the deployment of Elasticsearch 6.2 on Openshift